### PR TITLE
Fix command line flags in Docker examples

### DIFF
--- a/source/tutorials/image-to-image/lightmycells.rst
+++ b/source/tutorials/image-to-image/lightmycells.rst
@@ -159,7 +159,7 @@ Then, you can train by you own those models or you can use directly our checkpoi
                         --mount type=bind,source=$job_cfg_file,target=$job_cfg_file \
                         --mount type=bind,source=$result_dir,target=$result_dir \
                         --mount type=bind,source=$data_dir,target=$data_dir \
-                        BiaPyX/biapy \
+                        biapyx/biapy:latest-11.8 \
                             --config $job_cfg_file \
                             --result_dir $result_dir \
                             --name $job_name \

--- a/source/tutorials/image-to-image/lightmycells.rst
+++ b/source/tutorials/image-to-image/lightmycells.rst
@@ -160,11 +160,11 @@ Then, you can train by you own those models or you can use directly our checkpoi
                         --mount type=bind,source=$result_dir,target=$result_dir \
                         --mount type=bind,source=$data_dir,target=$data_dir \
                         BiaPyX/biapy \
-                            -cfg $job_cfg_file \
-                            -rdir $result_dir \
-                            -name $job_name \
-                            -rid $job_counter \
-                            -gpu "$gpu_number"
+                            --config $job_cfg_file \
+                            --result_dir $result_dir \
+                            --name $job_name \
+                            --run_id $job_counter \
+                            --gpu "$gpu_number"
 
                 .. note:: 
                     Note that ``data_dir`` must contain all the paths ``DATA.*.PATH`` and ``DATA.*.GT_PATH`` so the container can find them. For instance, if you want to only train in this example ``DATA.TRAIN.PATH`` and ``DATA.TRAIN.GT_PATH`` could be ``/home/user/data/train/x`` and ``/home/user/data/train/y`` respectively. 

--- a/source/workflows/classification.rst
+++ b/source/workflows/classification.rst
@@ -493,7 +493,7 @@ BiaPy offers different options to run workflows depending on your degree of comp
                 --mount type=bind,source=$job_cfg_file,target=$job_cfg_file \
                 --mount type=bind,source=$result_dir,target=$result_dir \
                 --mount type=bind,source=$data_dir,target=$data_dir \
-                BiaPyX/biapy \
+                biapyx/biapy:latest-11.8 \
                     --config $job_cfg_file \
                     --result_dir $result_dir \
                     --name $job_name \

--- a/source/workflows/classification.rst
+++ b/source/workflows/classification.rst
@@ -494,11 +494,11 @@ BiaPy offers different options to run workflows depending on your degree of comp
                 --mount type=bind,source=$result_dir,target=$result_dir \
                 --mount type=bind,source=$data_dir,target=$data_dir \
                 BiaPyX/biapy \
-                    -cfg $job_cfg_file \
-                    -rdir $result_dir \
-                    -name $job_name \
-                    -rid $job_counter \
-                    -gpu "$gpu_number"
+                    --config $job_cfg_file \
+                    --result_dir $result_dir \
+                    --name $job_name \
+                    --run_id $job_counter \
+                    --gpu "$gpu_number"
 
         .. note:: 
             Note that ``data_dir`` must contain the path ``DATA.*.PATH`` so the container can find it. For instance, if you want to only train in this example ``DATA.TRAIN.PATH`` could be ``/home/user/data/train/``. 

--- a/source/workflows/denoising.rst
+++ b/source/workflows/denoising.rst
@@ -389,7 +389,7 @@ BiaPy offers different options to run workflows depending on your degree of comp
                 --mount type=bind,source=$job_cfg_file,target=$job_cfg_file \
                 --mount type=bind,source=$result_dir,target=$result_dir \
                 --mount type=bind,source=$data_dir,target=$data_dir \
-                BiaPyX/biapy \
+                biapyx/biapy:latest-11.8 \
                     --config $job_cfg_file \
                     --result_dir $result_dir \
                     --name $job_name \

--- a/source/workflows/denoising.rst
+++ b/source/workflows/denoising.rst
@@ -390,11 +390,11 @@ BiaPy offers different options to run workflows depending on your degree of comp
                 --mount type=bind,source=$result_dir,target=$result_dir \
                 --mount type=bind,source=$data_dir,target=$data_dir \
                 BiaPyX/biapy \
-                    -cfg $job_cfg_file \
-                    -rdir $result_dir \
-                    -name $job_name \
-                    -rid $job_counter \
-                    -gpu "$gpu_number"
+                    --config $job_cfg_file \
+                    --result_dir $result_dir \
+                    --name $job_name \
+                    --run_id $job_counter \
+                    --gpu "$gpu_number"
 
         .. note:: 
             Note that ``data_dir`` must contain all the paths ``DATA.*.PATH`` and ``DATA.*.GT_PATH`` so the container can find them. For instance, if you want to only train in this example ``DATA.TRAIN.PATH`` and ``DATA.TRAIN.GT_PATH`` could be ``/home/user/data/train/x`` and ``/home/user/data/train/y`` respectively. 

--- a/source/workflows/detection.rst
+++ b/source/workflows/detection.rst
@@ -542,7 +542,7 @@ BiaPy offers different options to run workflows depending on your degree of comp
                 --mount type=bind,source=$job_cfg_file,target=$job_cfg_file \
                 --mount type=bind,source=$result_dir,target=$result_dir \
                 --mount type=bind,source=$data_dir,target=$data_dir \
-                BiaPyX/biapy \
+                biapyx/biapy:latest-11.8 \
                     --config $job_cfg_file \
                     --result_dir $result_dir \
                     --name $job_name \

--- a/source/workflows/detection.rst
+++ b/source/workflows/detection.rst
@@ -543,11 +543,11 @@ BiaPy offers different options to run workflows depending on your degree of comp
                 --mount type=bind,source=$result_dir,target=$result_dir \
                 --mount type=bind,source=$data_dir,target=$data_dir \
                 BiaPyX/biapy \
-                    -cfg $job_cfg_file \
-                    -rdir $result_dir \
-                    -name $job_name \
-                    -rid $job_counter \
-                    -gpu "$gpu_number"
+                    --config $job_cfg_file \
+                    --result_dir $result_dir \
+                    --name $job_name \
+                    --run_id $job_counter \
+                    --gpu "$gpu_number"
 
         .. note:: 
             Note that ``data_dir`` must contain all the paths ``DATA.*.PATH`` and ``DATA.*.GT_PATH`` so the container can find them. For instance, if you want to only train in this example ``DATA.TRAIN.PATH`` and ``DATA.TRAIN.GT_PATH`` could be ``/home/user/data/train/x`` and ``/home/user/data/train/y`` respectively. 

--- a/source/workflows/image_to_image.rst
+++ b/source/workflows/image_to_image.rst
@@ -514,11 +514,11 @@ BiaPy offers different options to run workflows depending on your degree of comp
                 --mount type=bind,source=$result_dir,target=$result_dir \
                 --mount type=bind,source=$data_dir,target=$data_dir \
                 BiaPyX/biapy \
-                    -cfg $job_cfg_file \
-                    -rdir $result_dir \
-                    -name $job_name \
-                    -rid $job_counter \
-                    -gpu "cuda:$gpu_number"
+                    --config $job_cfg_file \
+                    --result_dir $result_dir \
+                    --name $job_name \
+                    --run_id $job_counter \
+                    --gpu "cuda:$gpu_number"
 
         .. note:: 
             Note that ``data_dir`` must contain all the paths ``DATA.*.PATH`` and ``DATA.*.GT_PATH`` so the container can find them. For instance, if you want to only train in this example ``DATA.TRAIN.PATH`` and ``DATA.TRAIN.GT_PATH`` could be ``/home/user/data/train/x`` and ``/home/user/data/train/y`` respectively. 

--- a/source/workflows/image_to_image.rst
+++ b/source/workflows/image_to_image.rst
@@ -513,7 +513,7 @@ BiaPy offers different options to run workflows depending on your degree of comp
                 --mount type=bind,source=$job_cfg_file,target=$job_cfg_file \
                 --mount type=bind,source=$result_dir,target=$result_dir \
                 --mount type=bind,source=$data_dir,target=$data_dir \
-                BiaPyX/biapy \
+                biapyx/biapy:latest-11.8 \
                     --config $job_cfg_file \
                     --result_dir $result_dir \
                     --name $job_name \

--- a/source/workflows/instance_segmentation.rst
+++ b/source/workflows/instance_segmentation.rst
@@ -535,11 +535,11 @@ BiaPy offers different options to run workflows depending on your degree of comp
               --mount type=bind,source=$result_dir,target=$result_dir \
               --mount type=bind,source=$data_dir,target=$data_dir \
               BiaPyX/biapy \
-                  -cfg $job_cfg_file \
-                  -rdir $result_dir \
-                  -name $job_name \
-                  -rid $job_counter \
-                  -gpu "$gpu_number"
+                  --config $job_cfg_file \
+                  --result_dir $result_dir \
+                  --name $job_name \
+                  --run_id $job_counter \
+                  --gpu "$gpu_number"
 
       .. note:: 
           Note that ``data_dir`` must contain all the paths ``DATA.*.PATH`` and ``DATA.*.GT_PATH`` so the container can find them. For instance, if you want to only train in this example ``DATA.TRAIN.PATH`` and ``DATA.TRAIN.GT_PATH`` could be ``/home/user/data/train/x`` and ``/home/user/data/train/y`` respectively. 

--- a/source/workflows/instance_segmentation.rst
+++ b/source/workflows/instance_segmentation.rst
@@ -534,7 +534,7 @@ BiaPy offers different options to run workflows depending on your degree of comp
               --mount type=bind,source=$job_cfg_file,target=$job_cfg_file \
               --mount type=bind,source=$result_dir,target=$result_dir \
               --mount type=bind,source=$data_dir,target=$data_dir \
-              BiaPyX/biapy \
+              biapyx/biapy:latest-11.8 \
                   --config $job_cfg_file \
                   --result_dir $result_dir \
                   --name $job_name \

--- a/source/workflows/self_supervision.rst
+++ b/source/workflows/self_supervision.rst
@@ -392,11 +392,11 @@ BiaPy offers different options to run workflows depending on your degree of comp
                 --mount type=bind,source=$result_dir,target=$result_dir \
                 --mount type=bind,source=$data_dir,target=$data_dir \
                 BiaPyX/biapy \
-                    -cfg $job_cfg_file \
-                    -rdir $result_dir \
-                    -name $job_name \
-                    -rid $job_counter \
-                    -gpu "$gpu_number"
+                    --config $job_cfg_file \
+                    --result_dir $result_dir \
+                    --name $job_name \
+                    --run_id $job_counter \
+                    --gpu "$gpu_number"
 
         .. note:: 
             Note that ``data_dir`` must contain the path ``DATA.*.PATH`` so the container can find it. For instance, if you want to only train in this example ``DATA.TRAIN.PATH`` could be ``/home/user/data/train/x``. 

--- a/source/workflows/self_supervision.rst
+++ b/source/workflows/self_supervision.rst
@@ -391,7 +391,7 @@ BiaPy offers different options to run workflows depending on your degree of comp
                 --mount type=bind,source=$job_cfg_file,target=$job_cfg_file \
                 --mount type=bind,source=$result_dir,target=$result_dir \
                 --mount type=bind,source=$data_dir,target=$data_dir \
-                BiaPyX/biapy \
+                biapyx/biapy:latest-11.8 \
                     --config $job_cfg_file \
                     --result_dir $result_dir \
                     --name $job_name \

--- a/source/workflows/semantic_segmentation.rst
+++ b/source/workflows/semantic_segmentation.rst
@@ -559,7 +559,7 @@ BiaPy offers different options to run workflows depending on your degree of comp
                 --mount type=bind,source=$job_cfg_file,target=$job_cfg_file \
                 --mount type=bind,source=$result_dir,target=$result_dir \
                 --mount type=bind,source=$data_dir,target=$data_dir \
-                BiaPyX/biapy \
+                biapyx/biapy:latest-11.8 \
                     --config $job_cfg_file \
                     --result_dir $result_dir \
                     --name $job_name \

--- a/source/workflows/semantic_segmentation.rst
+++ b/source/workflows/semantic_segmentation.rst
@@ -560,11 +560,11 @@ BiaPy offers different options to run workflows depending on your degree of comp
                 --mount type=bind,source=$result_dir,target=$result_dir \
                 --mount type=bind,source=$data_dir,target=$data_dir \
                 BiaPyX/biapy \
-                    -cfg $job_cfg_file \
-                    -rdir $result_dir \
-                    -name $job_name \
-                    -rid $job_counter \
-                    -gpu "$gpu_number"
+                    --config $job_cfg_file \
+                    --result_dir $result_dir \
+                    --name $job_name \
+                    --run_id $job_counter \
+                    --gpu "$gpu_number"
 
         .. note:: 
 

--- a/source/workflows/super_resolution.rst
+++ b/source/workflows/super_resolution.rst
@@ -552,11 +552,11 @@ BiaPy offers different options to run workflows depending on your degree of comp
                 --mount type=bind,source=$result_dir,target=$result_dir \
                 --mount type=bind,source=$data_dir,target=$data_dir \
                 BiaPyX/biapy \
-                    -cfg $job_cfg_file \
-                    -rdir $result_dir \
-                    -name $job_name \
-                    -rid $job_counter \
-                    -gpu "$gpu_number"
+                    --config $job_cfg_file \
+                    --result_dir $result_dir \
+                    --name $job_name \
+                    --run_id $job_counter \
+                    --gpu "$gpu_number"
 
         .. note:: 
             Note that ``data_dir`` must contain all the paths ``DATA.*.PATH`` and ``DATA.*.GT_PATH`` so the container can find them. For instance, if you want to only train in this example ``DATA.TRAIN.PATH`` and ``DATA.TRAIN.GT_PATH`` could be ``/home/user/data/train/x`` and ``/home/user/data/train/y`` respectively. 

--- a/source/workflows/super_resolution.rst
+++ b/source/workflows/super_resolution.rst
@@ -551,7 +551,7 @@ BiaPy offers different options to run workflows depending on your degree of comp
                 --mount type=bind,source=$job_cfg_file,target=$job_cfg_file \
                 --mount type=bind,source=$result_dir,target=$result_dir \
                 --mount type=bind,source=$data_dir,target=$data_dir \
-                BiaPyX/biapy \
+                biapyx/biapy:latest-11.8 \
                     --config $job_cfg_file \
                     --result_dir $result_dir \
                     --name $job_name \


### PR DESCRIPTION
I attempted to run BiaPy via Docker using the following command, with environment variables set as described in the documentation:
```shell
docker run --rm \
    --mount type=bind,source=$dir,target=$dir \
    biapyx/biapy:latest-11.8 \
        -cfg $job_cfg_file \
        -rdir $result_dir \
        -name $job_name \
        -rid $job_counter \
        -gpu "$gpu_number"
```

But I received an error:
```
usage: main.py [-h] --config CONFIG [--result_dir RESULT_DIR] [--name NAME]
               [--run_id RUN_ID] [--gpu GPU] [-v] [--world_size WORLD_SIZE]
               [--local_rank LOCAL_RANK] [--dist_on_itp] [--dist_url DIST_URL]
               [--dist_backend {nccl,gloo}]
main.py: error: the following arguments are required: --config
ERROR conda.cli.main_run:execute(125): `conda run python3 -u /installations/BiaPy/main.py -cfg /home/curtis/Downloads/BiaPy/CartoCell/cartocell_training.yaml -rdir /home/curtis/Downloads/BiaPy/CartoCell/exp_results -name cartocell_training -rid 1` failed. (See above for error)
```

It looks like the CLI flags changed. I like the new ones better (more standard *nix style), but the documentation is now incorrect. So here's a PR fixing it up.

The old image target of `BiaPyX/biapy` also didn't work for me, for two reasons: 1) incorrect case; and 2) lack of a `latest` tag as is the default when no tag is given.