### PR TITLE
Fix Mamba installation instructions

### DIFF
--- a/source/get_started/installation.rst
+++ b/source/get_started/installation.rst
@@ -251,7 +251,7 @@ Choose your installation method
 
                * Install BiaPy Dependencies: ::
                     
-                    mamba install pytz asciitree tzdata typer tqdm torchinfo tifffile threadpoolctl six Shapely scipy ruamel.yaml.clib pyparsing protobuf numcodecs lazy_loader kiwisolver joblib h5py fonttools fastremap fasteners cycler contourpy zarr=2.16.1 scikit-learn=1.4.0 scikit-image ruamel.yaml python-dateutil pydot=1.4.2 pandas matplotlib bioimageio.spec=0.4.9 xarray imgaug bioimageio.core=0.6.7
+                    mamba install pytz asciitree tzdata typer tqdm torchinfo tifffile threadpoolctl six Shapely scipy ruamel.yaml.clib pyparsing protobuf numcodecs lazy_loader kiwisolver joblib h5py fonttools fastremap fasteners cycler contourpy zarr=2.16.1 scikit-learn=1.4.0 scikit-image ruamel.yaml python-dateutil pydot=1.4.2 pandas matplotlib bioimageio.spec xarray imgaug bioimageio.core=0.6.7
 
                * Install packages not available on conda-forge, so install it via pip: ::
                     

--- a/source/get_started/installation.rst
+++ b/source/get_started/installation.rst
@@ -251,7 +251,11 @@ Choose your installation method
 
                * Install BiaPy Dependencies: ::
                     
-                    mamba install pytz asciitree tzdata typer tqdm torchinfo tifffile threadpoolctl six Shapely scipy ruamel.yaml.clib pyparsing protobuf numcodecs lazy_loader kiwisolver joblib h5py fonttools fastremap fasteners cycler contourpy zarr=2.16.1 scikit-learn=1.4.0 scikit-image ruamel.yaml python-dateutil pydot=1.4.2 pandas matplotlib bioimageio.spec xarray imgaug bioimageio.core=0.6.7
+                    mamba install pytz asciitree tzdata typer tqdm torchinfo tifffile threadpoolctl
+                    mamba install six Shapely scipy ruamel.yaml.clib pyparsing protobuf numcodecs lazy_loader kiwisolver
+                    mamba install joblib h5py fonttools fastremap fasteners cycler contourpy zarr=2.16.1 scikit-learn=1.4.0
+                    mamba install scikit-image ruamel.yaml python-dateutil pydot=1.4.2 pandas matplotlib xarray imgaug
+                    mamba install bioimageio.spec bioimageio.core=0.6.7
 
                * Install packages not available on conda-forge, so install it via pip: ::
                     


### PR DESCRIPTION
The new "Mamba + pip" section of the Command line installation instructions did not quite work for me. The "Install BiaPy Dependencies" step sat crunching for several minutes trying to solve, until finally I killed it. I then broke down the dependency list into chunks, installing a few at a time, each of which executed in a much more reasonable timeframe, until I got hit this:

```
$ mamba install bioimageio.spec=0.4.9 xarray imgaug bioimageio.core=0.6.7
...
error    libmamba Could not solve for environment specs
    The following packages are incompatible
    ├─ bioimageio.core =0.6.7 is installable and it requires
    │  └─ bioimageio.spec =0.5.3, which can be installed;
    └─ bioimageio.spec =0.4.9 is not installable because it conflicts with any installable versions previously reported.
critical libmamba Could not solve for environment specs
```

Removing the `=0.4.9` from `bioimageio.spec` allowed the solve to succeed, choosing version `0.5.3.5` instead. This is actually critical anyway, because with 0.4.9 installed I received an error when running BiaPy via the CLI:

```
/home/curtis/miniforge3/envs/biapy/lib/python3.10/site-packages/bioimageio/spec/shared/_resolve_source.py:482: UserWarning: Download (6948) does not have expected size (2467).
  warnings.warn(f"Download ({t.n}) does not have expected size ({total_size}).")
collection.json: 235kiB [00:00, 31.3MiB/s]
/home/curtis/miniforge3/envs/biapy/lib/python3.10/site-packages/bioimageio/spec/shared/_resolve_source.py:482: UserWarning: Download (234788) does not have expected size (28539).
  warnings.warn(f"Download ({t.n}) does not have expected size ({total_size}).")
Traceback (most recent call last):
  File "/home/curtis/code/biapy/BiaPy/main.py", line 1, in <module>
    from biapy import main
  File "/home/curtis/code/biapy/BiaPy/biapy/__init__.py", line 6, in <module>
    from ._biapy import BiaPy
  File "/home/curtis/code/biapy/BiaPy/biapy/_biapy.py", line 18, in <module>
    from bioimageio.spec.model.v0_5 import (
ModuleNotFoundError: No module named 'bioimageio.spec.model.v0_5'
```
