### PR TITLE
Note that Linux Docker users can use Docker Engine

### DIFF
--- a/source/get_started/installation.rst
+++ b/source/get_started/installation.rst
@@ -70,9 +70,9 @@ Choose your installation method
 
            .. tab:: Linux  
 
-                You will need to follow the steps described `here <https://docs.docker.com/desktop/install/linux-install/>`__. 
+                You need to install either `Docker Desktop <https://docs.docker.com/desktop/install/linux-install/>`__ (friendlier but not open source) or `Docker Engine <https://docs.docker.com/engine/install/>`__ (open source but command line only).
            
-                If you follow the steps and still have problems maybe you need to add your user to docker group: ::
+                If you follow the steps and still have problems, you may need to add your user to docker group: ::
                     
                     sudo usermod -aG docker $USER
                     newgrp docker
@@ -155,9 +155,9 @@ Choose your installation method
 
            .. tab:: Linux  
 
-                You will need to follow the steps described `here <https://docs.docker.com/desktop/install/linux-install/>`__. 
+                You need to install either `Docker Desktop <https://docs.docker.com/desktop/install/linux-install/>`__ (friendlier but not open source) or `Docker Engine <https://docs.docker.com/engine/install/>`__ (open source but command line only).
            
-                If you follow the steps and still have problems maybe you need to add your user to docker group: ::
+                If you follow the steps and still have problems, you may need to add your user to docker group: ::
                     
                     sudo usermod -aG docker $USER
                     newgrp docker


### PR DESCRIPTION
I wanted to use Docker Engine rather than Docker Desktop, to stay open source. The instructions indicated that I needed to install Docker Desktop specifically, even on Linux, so here's a patch clarifying that Docker Engine also works.